### PR TITLE
Enhance the Golang cheatsheet

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -253,7 +253,7 @@ func Deferred() {
 
 ```go
 import (
-	"strings"
+    "strings"
 )
 
 strings.Contains("seafood", "eaf") // => true
@@ -268,7 +268,7 @@ strings.TrimSpace("   test   ") // => "test"
 
 ```go
 import (
-	"regexp"
+    "regexp"
 )
 
 compiledRegex := regexp.MustCompile(`([a-z]+)=([0-9]+)`)
@@ -279,7 +279,10 @@ compiledRegex.FindAllString(exampleString, -1) // => ["key=1", "otherkey=5", "ne
 
 // n = -1 means find all matches (limit matches with positive number)
 compiledRegex.FindAllStringSubmatch(exampleString, -1)
-// => [["key=1", "key", "1"], ["otherkey=5", "otherkey", "5"], ["nextkey=100", "nextkey", "100"]]
+// => [
+//    ["key=1", "key", "1"],
+//    ["otherkey=5", "otherkey", "5"],
+//    ["nextkey=100", "nextkey", "100"]]
 ```
 
 ## JSON
@@ -288,13 +291,13 @@ compiledRegex.FindAllStringSubmatch(exampleString, -1)
 
 ```go
 import (
-	"fmt"
-	"encoding/json"
+    "fmt"
+    "encoding/json"
 )
 
 type ResponseItem struct {
-	Name string `json:"name"`
-	Age int `json:"age"`
+    Name string `json:"name"`
+    Age int `json:"age"`
 }
 
 body := []byte("{\"name\": \"Johnny Appleseed\", \"age\": 18}")
@@ -308,13 +311,13 @@ json.Unmarshal(body, &parsed)
 
 ```go
 import (
-	"fmt"
-	"encoding/json"
+    "fmt"
+    "encoding/json"
 )
 
 type ResponseItem struct {
-	Name string `json:"name"`
-	Age int `json:"age"`
+    Name string `json:"name"`
+    Age int `json:"age"`
 }
 
 responseItem := ResponseItem {
@@ -332,8 +335,8 @@ text := string(byteString)
 
 ```go
 import (
-	"io"
-	"net/http"
+    "io"
+    "net/http"
 )
 
 resp, _ := http.Get("https://www.google.com/humans.txt")
@@ -347,17 +350,17 @@ stringBody := string(body)
 
 ```go
 import (
-	"io"
-	"fmt"
-	"bytes"
-	"net/http"
-	"encoding/json"
+    "io"
+    "fmt"
+    "bytes"
+    "net/http"
+    "encoding/json"
 )
 
 type ResponseItem struct {
-	Title string `json:"title"`
-	Body string `json:"body"`
-	UserId int `json:"userId"`
+    Title string `json:"title"`
+    Body string `json:"body"`
+    UserId int `json:"userId"`
 }
 
 // Create POST body and convert to bytes

--- a/golang/README.md
+++ b/golang/README.md
@@ -248,3 +248,135 @@ func Deferred() {
     fmt.Println("Started")
 }
 ```
+
+## Strings
+
+```go
+import (
+	"strings"
+)
+
+strings.Contains("seafood", "eaf") // => true
+strings.Fields("  foo bar baz  ") // => ["foo", "bar", "baz"]
+strings.Join([]string{"a", "b", "c"}, ",") // => "a,b,c"
+strings.ToUpper("test") // => "TEST"
+strings.ToLower("TEST")) // => "test"
+strings.TrimSpace("   test   ") // => "test"
+```
+
+## Regular Expressions
+
+```go
+import (
+	"regexp"
+)
+
+compiledRegex := regexp.MustCompile(`([a-z]+)=([0-9]+)`)
+exampleString := "key=1  otherkey=5 || nextkey=100"
+
+// n = -1 means find all matches (limit matches with positive number)
+compiledRegex.FindAllString(exampleString, -1) // => ["key=1", "otherkey=5", "nextkey=100"]
+
+// n = -1 means find all matches (limit matches with positive number)
+compiledRegex.FindAllStringSubmatch(exampleString, -1)
+// => [["key=1", "key", "1"], ["otherkey=5", "otherkey", "5"], ["nextkey=100", "nextkey", "100"]]
+```
+
+## JSON
+
+### Decoding
+
+```go
+import (
+	"fmt"
+	"encoding/json"
+)
+
+type ResponseItem struct {
+	Name string `json:"name"`
+	Age int `json:"age"`
+}
+
+body := []byte("{\"name\": \"Johnny Appleseed\", \"age\": 18}")
+
+// Convert JSON to struct
+var parsed ResponseItem
+json.Unmarshal(body, &parsed)
+```
+
+### Encoding
+
+```go
+import (
+	"fmt"
+	"encoding/json"
+)
+
+type ResponseItem struct {
+	Name string `json:"name"`
+	Age int `json:"age"`
+}
+
+responseItem := ResponseItem {
+    Name: "Firstname Lastname",
+    Age: 57,
+}
+
+byteString, _ := json.Marshal(responseItem)
+text := string(byteString)
+```
+
+## HTTP Requests
+
+### GET
+
+```go
+import (
+	"io"
+	"net/http"
+)
+
+resp, _ := http.Get("https://www.google.com/humans.txt")
+
+// Read the response into a string
+body, _ := io.ReadAll(resp.Body)
+stringBody := string(body)
+```
+
+### POST
+
+```go
+import (
+	"io"
+	"fmt"
+	"bytes"
+	"net/http"
+	"encoding/json"
+)
+
+type ResponseItem struct {
+	Title string `json:"title"`
+	Body string `json:"body"`
+	UserId int `json:"userId"`
+}
+
+// Create POST body and convert to bytes
+postBody, _ := json.Marshal(map[string]any{
+    "title": "My Title",
+    "body:": "Example body",
+    "userId": 1,
+})
+buffer := bytes.NewBuffer(postBody)
+
+// Make the request
+resp, _ := http.Post(
+    "https://jsonplaceholder.typicode.com/posts",
+    "application/json",
+    buffer,
+)
+responseText, _ := io.ReadAll(resp.Body)
+
+// Parse the JSON response
+var parsed ResponseItem
+json.Unmarshal(responseText, &parsed)
+```


### PR DESCRIPTION
Adds examples for the following Golang standard library modules:
- `net/http`
- `encoding/json`
- `strings`
- `regexp`