### PR TITLE
Add clarification on trailing-slash behavior for rsync source paths

### DIFF
--- a/rsync/README.md
+++ b/rsync/README.md
@@ -6,19 +6,32 @@
 
 ## Basic Usage
 
-```bash
-# Sync two directories (in "archive" mode)
-rsync -aP /home/user/folder /mnt/drive/folder
+The following commands perform the same task:
 
-# Equivalent statements include "/" after both the source and destination
-rsync -aP /home/user/folder/ /mnt/drive/folder/
+```bash
+# Synchronizes the /home/user/folder with /mnt/drive/folder (in archive mode)
+rsync -aP /home/user/folder /mnt/drive
+
+# Synchronizes the /home/user/folder with /mnt/drive/folder (in archive mode)
+rsync -aP /home/user/folder/ /mnt/drive/folder
 ```
 
-Adding a `/` after the directory path refers to the elements within the
-directory, instead of the directory itself:
+### The Trailing Slash
+
+The command-line syntax of `rsync` can be confusing because of its "trailing
+slash" behavior. According to the manual page (`man rsync`):
+
+> A trailing slash on the source changes this behavior to avoid creating an
+> additional directory level at the destination. You can think of a trailing
+> `/` on a source as meaning "copy the contents of this directory" as opposed
+> to "copy the directory by name", but in both cases the attributes of the
+> containing directory are transferred to the containing directory on the
+> destination. In other words, each of the following commands copies the files
+> in the same way, including their setting of the attributes of `/dest/foo`:
 
 ```bash
-rsync -r
+rsync -av /src/foo /dest
+rsync -av /src/foo/ /dest/foo
 ```
 
 ### Notes
@@ -37,19 +50,19 @@ Copy all files and folders from the `src` to `target` folder, deleting anything
 in `target` not in `src`:
 
 ```bash
-rsync --delete -rtP src target
+rsync --delete -rtP src/ target
 ```
 
 Delete files *before* the transfer:
 
 ```bash
-rsync --delete-before -rtP src target
+rsync --delete-before -rtP src/ target
 ```
 
 Delete files *after* the transfer:
 
 ```bash
-rsync --delete-after -rtP src target
+rsync --delete-after -rtP src/ target
 ```
 
 ## Show Progress
@@ -57,8 +70,8 @@ rsync --delete-after -rtP src target
 Show the progress of an active transfer (using `-p` or `--progress`):
 
 ```bash
-rsync --progress -rt src target
-rsync -rtP src target
+rsync --progress -rt src/ target
+rsync -rtP src/ target
 ```
 
 ## Exclude Filenames
@@ -66,7 +79,7 @@ rsync -rtP src target
 Exclude files matching a pattern (such as all `.jpg` files):
 
 ```bash
-rsync --exclude '*.jpg' -rtP src target
+rsync --exclude '*.jpg' -rtP src/ target
 ```
 
 ## Dry Run
@@ -75,7 +88,7 @@ For safety reasons, one can perform a "dry run," in which the outcome of a
 command is simulated, but no real filesystem changes are made:
 
 ```bash
-rsync --dry-run -rtP src target
+rsync --dry-run -rtP src/ target
 ```
 
 ## Show Detailed Change Logs
@@ -83,7 +96,7 @@ rsync --dry-run -rtP src target
 Prints a detailed change log after running a command:
 
 ```bash
-rsync --itemize-changes -rtP src target
+rsync --itemize-changes -rtP src/ target
 ```
 
 Produces output similar to this:
@@ -100,13 +113,13 @@ Produces output similar to this:
 Synchronize two folders but exclude files *larger* than `3G`:
 
 ```bash
-rsync --max-size=3G -rtP src target
+rsync --max-size=3G -rtP src/ target
 ```
 
 Synchronize two folders but exclude files *smaller* than `1.5K`:
 
 ```bash
-rsync --min-size=1.5K -rtP src target
+rsync --min-size=1.5K -rtP src/ target
 ```
 
 ## Common Issues
@@ -124,5 +137,5 @@ When synchronizing directories to or from `fat` filesystems, use the
 `--modify-window` flag to allow for time differences up to a second:
 
 ```bash
-rsync --modify-window=1 -rtP my_folder /mnt/usb/my_folder
+rsync --modify-window=1 -rtP my_folder/ /mnt/usb/my_folder
 ```


### PR DESCRIPTION
Fixes bad information about trailing slashes in `rsync` source paths