### PR TITLE
Add section to Python for context managers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@types/katex": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
-      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true,
       "license": "MIT"
     },
@@ -218,9 +218,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -313,6 +313,7 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -462,9 +463,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.27",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.27.tgz",
-      "integrity": "sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==",
+      "version": "0.16.28",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
+      "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",

--- a/python/README.md
+++ b/python/README.md
@@ -192,6 +192,82 @@ nd = datetime.date(year=2011, month=5, day=1) + datetime.timedelta(days=5)
 nd.isoformat() # '2011-05-06'
 ```
 
+## Context Managers
+
+Context managers allow for the concise, convenient allocation, use, and
+automatic deallocation of resources using the `with` keyword. A context manager
+can be created quickly with the `contextlib` module, or constructed as a class.
+
+### Class-Based Context Manager
+
+All synchronous class-based context managers fit the form of
+`contextlib.AbstractContextManager`, defining `__enter__` and `__exit__`. The
+return value of `__enter__` is bound to the variable defined in the `with`
+statement, while `__exit__` cleans up when the interior code is finished:
+
+```python
+from types import TracebackType
+from contextlib import AbstractContextManager
+
+
+class ContextManager(AbstractContextManager):
+    def __enter__(self) -> str:
+        print('Entering the context manager')
+        return 'Hello!'
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None,
+        exc_value: BaseException | None, traceback: TracebackType | None
+    ) -> None:
+        # Do cleanup here
+        print('Exiting the context manager')
+
+
+with ContextManager() as provided_var:
+    print(provided_var)
+```
+
+This creates the following output:
+
+```text
+Entering the context manager
+Hello!
+Exiting the context manager
+```
+
+**Note:** In cases where an exception is thrown by the code within the context
+manager, `exc_type`, `exc_value`, and `traceback` will be passed to `__exit__`.
+Otherwise, these values are `None`.
+
+### Yield-Based Context Manager
+
+The `contextlib` library also provides the `contextmanager` decorator, which
+allows for very simple context managers to be created as generator functions
+with the `yield` keyword:
+
+```python
+from contextlib import contextmanager
+
+
+@contextmanager
+def context_manager(number: int):
+    print('Entering context manager')
+    yield f'The number is {number}'
+    print('Exiting context manager')
+
+
+with context_manager(number=10) as provided_var:
+    print(provided_var)
+```
+
+Which creates the following output:
+
+```text
+Entering context manager
+The number is 10
+Exiting context manager
+```
+
 ## Command-Line Arguments
 
 Python has built-in support for handling command-line utilities using its


### PR DESCRIPTION
- Adds section to *Python* cheatsheet with information about class-based and yield-based context managers
- Updates `npm` dependencies for linter